### PR TITLE
Added start of round  phase for Everblaze Comet

### DIFF
--- a/src/army/stormcast_eternals/endless_spells.ts
+++ b/src/army/stormcast_eternals/endless_spells.ts
@@ -68,13 +68,18 @@ export const EndlessSpells: TEndlessSpells = [
       },
       {
         name: `Burning Vengeance`,
-        desc: `After this model is set up, roll a dice for each unit within 10" of this model. On a 1‑2, that unit suffers 1 mortal wound. On a 3‑4, that unit suffers D3 mortal wounds. On a 5‑6, that unit suffers 3 mortal wounds. In addition, at the start of each battle round, roll a dice for each unit within 5" of this model. On a 1‑3, that unit suffers 1 mortal wound. On a 4‑6, that unit suffers D3 mortal wounds.`,
+        desc: `After this model is set up, roll a dice for each unit within 10" of this model. On a 1‑2, that unit suffers 1 mortal wound. On a 3‑4, that unit suffers D3 mortal wounds. On a 5‑6, that unit suffers 3 mortal wounds.`,
         when: [HERO_PHASE],
       },
       {
         name: `Arcane Disruption`,
         desc: `Subtract 1 from casting rolls for WIZARDS while they are within 5" of this model.`,
         when: [HERO_PHASE],
+      },
+      {
+        name: `Burning Vengeance`,
+        desc: `At the start of each battle round, roll a dice for each unit within 5" of this model. On a 1‑3, that unit suffers 1 mortal wound. On a 4‑6, that unit suffers D3 mortal wounds.`,
+        when: [START_OF_ROUND],
       },
     ],
   },


### PR DESCRIPTION
I find that the second-half of Burning Vengeance is easily missed. With that in mind, it might be helpful to split the description into multiple phases. Also, clean up the text to reflect what happens in each phase.